### PR TITLE
Creates a "logs" folder at first launch

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,8 @@
+from os import mkdir, path
+
 class LogFile():
     def __init__(self, timestamp):
+        if not path.exists("./logs"): mkdir("./logs") # Create a logs folder, if it not exists at first launch
         self.name = str(timestamp).replace(' ', '_').replace(':', '-')
         print(self.name)
         self.path = 'logs/' + self.name + '.txt'


### PR DESCRIPTION
During the first run, the "logs" folder is not created, causing an error when creating the log file. I fixed the error by adding a function to create the "logs" folder if it does not exist.